### PR TITLE
Add RBAC required for presence to work

### DIFF
--- a/deploy/presence.yaml
+++ b/deploy/presence.yaml
@@ -6,3 +6,28 @@ metadata:
 spec:
   containers:
   - image: cloudstateio/samples-java-chat-presence:latest
+
+--- 
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-pods
+subjects:
+  # Uses the default service account.
+  # Consider creating a dedicated service account to run your
+  # Akka Cluster services and binding the role to that one.
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The akka-sidecar needs pod read-only privileges to form the cluster.